### PR TITLE
Improve test coverage in table initializer

### DIFF
--- a/spec/adapters/datatables_spec.rb
+++ b/spec/adapters/datatables_spec.rb
@@ -4,6 +4,8 @@ describe Daru::View::Table, 'table using daru-data_tables' do
   before { Daru::View.table_library = :datatables }
   before(:each) do
     @data_array = [[1, 15], [2, 30], [4, 40]]
+    @string_array = [[1, 15], ["daru", "view"]]
+
     @data_vec1 = Daru::Vector.new([1 ,2, 4])
     @data_vec2 = Daru::Vector.new([15 ,30, 40])
     @data_df = Daru::DataFrame.new(arr1: @data_vec1, arr2: @data_vec2)
@@ -14,8 +16,18 @@ describe Daru::View::Table, 'table using daru-data_tables' do
   end
 
   describe "initialization Tables" do
-    it "Table class must be Daru::DataTables::DataTable " do
+    it "Table class must be Daru::DataTables::DataTable" do
       expect(Daru::View::Table.new.table).to be_a Daru::DataTables::DataTable
+    end
+
+    it "Table class must be Daru::DataTables::DataTable when data objects" \
+       " are not of class Array" do
+      expect(Daru::View::Table.new(@string_array, @options).table).to be_a Daru::DataTables::DataTable
+    end
+
+    it "Table class must be Daru::DataTables::DataTable when data objects" \
+       " are of class Array" do
+      expect(Daru::View::Table.new(@data_array, @options).table).to be_a Daru::DataTables::DataTable
     end
   end
 end

--- a/spec/adapters/datatables_spec.rb
+++ b/spec/adapters/datatables_spec.rb
@@ -21,7 +21,7 @@ describe Daru::View::Table, 'table using daru-data_tables' do
     end
 
     it "Table class must be Daru::DataTables::DataTable when data objects" \
-       " are not of class Array of Arrays" do
+       " are of class Array" do
       expect(Daru::View::Table.new(@string_array, @options).table).to be_a Daru::DataTables::DataTable
       expect(Daru::View::Table.new(@string_array, @options).data).to eq @string_array
       expect(Daru::View::Table.new(@string_array, @options).options).to eq @options

--- a/spec/adapters/datatables_spec.rb
+++ b/spec/adapters/datatables_spec.rb
@@ -13,6 +13,8 @@ describe Daru::View::Table, 'table using daru-data_tables' do
     @options = {width: 800, height: 720}
 
     @plot = Daru::View::Table.new(@data_df, @options)
+    @table_string_array = Daru::View::Table.new(@string_array, @options)
+    @table_array = Daru::View::Table.new(@data_array, @options)
   end
 
   describe "initialization Tables" do
@@ -22,16 +24,16 @@ describe Daru::View::Table, 'table using daru-data_tables' do
 
     it "Table class must be Daru::DataTables::DataTable when data objects" \
        " are of class Array" do
-      expect(Daru::View::Table.new(@string_array, @options).table).to be_a Daru::DataTables::DataTable
-      expect(Daru::View::Table.new(@string_array, @options).data).to eq @string_array
-      expect(Daru::View::Table.new(@string_array, @options).options).to eq @options
+      expect(@table_string_array.table).to be_a Daru::DataTables::DataTable
+      expect(@table_string_array.data).to eq @string_array
+      expect(@table_string_array.options).to eq @options
     end
 
     it "Table class must be Daru::DataTables::DataTable when data objects" \
        " are of class Array of Arrays" do
-      expect(Daru::View::Table.new(@data_array, @options).table).to be_a Daru::DataTables::DataTable
-      expect(Daru::View::Table.new(@data_array, @options).data).to eq @data_array
-      expect(Daru::View::Table.new(@data_array, @options).options).to eq @options
+      expect(@table_array.table).to be_a Daru::DataTables::DataTable
+      expect(@table_array.data).to eq @data_array
+      expect(@table_array.options).to eq @options
     end
   end
 end

--- a/spec/adapters/datatables_spec.rb
+++ b/spec/adapters/datatables_spec.rb
@@ -21,13 +21,17 @@ describe Daru::View::Table, 'table using daru-data_tables' do
     end
 
     it "Table class must be Daru::DataTables::DataTable when data objects" \
-       " are not of class Array" do
+       " are not of class Array of Arrays" do
       expect(Daru::View::Table.new(@string_array, @options).table).to be_a Daru::DataTables::DataTable
+      expect(Daru::View::Table.new(@string_array, @options).data).to eq @string_array
+      expect(Daru::View::Table.new(@string_array, @options).options).to eq @options
     end
 
     it "Table class must be Daru::DataTables::DataTable when data objects" \
-       " are of class Array" do
+       " are of class Array of Arrays" do
       expect(Daru::View::Table.new(@data_array, @options).table).to be_a Daru::DataTables::DataTable
+      expect(Daru::View::Table.new(@data_array, @options).data).to eq @data_array
+      expect(Daru::View::Table.new(@data_array, @options).options).to eq @options
     end
   end
 end

--- a/spec/adapters/datatables_spec.rb
+++ b/spec/adapters/datatables_spec.rb
@@ -4,7 +4,7 @@ describe Daru::View::Table, 'table using daru-data_tables' do
   before { Daru::View.table_library = :datatables }
   before(:each) do
     @data_array = [[1, 15], [2, 30], [4, 40]]
-    @string_array = [[1, 15], ["daru", "view"]]
+    @string_array = ["daru", "view"]
 
     @data_vec1 = Daru::Vector.new([1 ,2, 4])
     @data_vec2 = Daru::Vector.new([15 ,30, 40])

--- a/spec/adapters/datatables_spec.rb
+++ b/spec/adapters/datatables_spec.rb
@@ -3,19 +3,18 @@ require 'spec_helper.rb'
 describe Daru::View::Table, 'table using daru-data_tables' do
   before { Daru::View.table_library = :datatables }
   before(:each) do
-    @data_array = [[1, 15], [2, 30], [4, 40]]
-    @string_array = ["daru", "view"]
-
     @data_vec1 = Daru::Vector.new([1 ,2, 4])
     @data_vec2 = Daru::Vector.new([15 ,30, 40])
     @data_df = Daru::DataFrame.new(arr1: @data_vec1, arr2: @data_vec2)
-
     @options = {width: 800, height: 720}
-
+    
     @plot = Daru::View::Table.new(@data_df, @options)
-    @table_string_array = Daru::View::Table.new(@string_array, @options)
-    @table_array = Daru::View::Table.new(@data_array, @options)
   end
+  let(:options) {{width: 800, height: 720}}
+  let(:string_array) {["daru", "view"]}
+  let(:data_array) {[[1, 15], [2, 30], [4, 40]]}
+  let(:table_string_array) { Daru::View::Table.new(string_array, options) }
+  let(:table_array) { Daru::View::Table.new(data_array, options) }
 
   describe "initialization Tables" do
     it "Table class must be Daru::DataTables::DataTable" do
@@ -24,16 +23,16 @@ describe Daru::View::Table, 'table using daru-data_tables' do
 
     it "Table class must be Daru::DataTables::DataTable when data objects" \
        " are of class Array" do
-      expect(@table_string_array.table).to be_a Daru::DataTables::DataTable
-      expect(@table_string_array.data).to eq @string_array
-      expect(@table_string_array.options).to eq @options
+      expect(table_string_array.table).to be_a Daru::DataTables::DataTable
+      expect(table_string_array.data).to eq string_array
+      expect(table_string_array.options).to eq options
     end
 
     it "Table class must be Daru::DataTables::DataTable when data objects" \
        " are of class Array of Arrays" do
-      expect(@table_array.table).to be_a Daru::DataTables::DataTable
-      expect(@table_array.data).to eq @data_array
-      expect(@table_array.options).to eq @options
+      expect(table_array.table).to be_a Daru::DataTables::DataTable
+      expect(table_array.data).to eq data_array
+      expect(table_array.options).to eq options
     end
   end
 end


### PR DESCRIPTION
Partial fix for the issue #67.
Tests were already present for an empty array being passed to the `data` parameter.
Adding tests when an array of arrays and array of strings is passed as `data`.
It improves coverage for the case when the `else` condition in https://github.com/SciRuby/daru-view/blob/master/lib/daru/view/adapters/datatables.rb#L24-L26 is executed.