### PR TITLE
Improve coverage for googlecharts.rb file

### DIFF
--- a/spec/adapters/googlecharts_spec.rb
+++ b/spec/adapters/googlecharts_spec.rb
@@ -30,5 +30,9 @@ describe Daru::View::Plot, 'plotting with googlecharts' do
     it "Table class must be GoogleVisualr::DataTable " do
       expect(Daru::View::Table.new.table).to be_a GoogleVisualr::DataTable
     end
+    it "Table class must be GoogleVisualr::DataTable when data objects are" \
+       " of class Daru::Vector" do
+      expect(Daru::View::Table.new(@data_vec1, @options).table).to be_a GoogleVisualr::DataTable
+    end
   end
 end

--- a/spec/adapters/googlecharts_spec.rb
+++ b/spec/adapters/googlecharts_spec.rb
@@ -33,6 +33,8 @@ describe Daru::View::Plot, 'plotting with googlecharts' do
     it "Table class must be GoogleVisualr::DataTable when data objects are" \
        " of class Daru::Vector" do
       expect(Daru::View::Table.new(@data_vec1, @options).table).to be_a GoogleVisualr::DataTable
+      expect(Daru::View::Table.new(@data_vec1, @options).options).to eq @options
+      expect(Daru::View::Table.new(@data_vec1, @options).data).to eq @data_vec1
     end
   end
 end

--- a/spec/adapters/googlecharts_spec.rb
+++ b/spec/adapters/googlecharts_spec.rb
@@ -3,14 +3,36 @@ require 'spec_helper.rb'
 describe Daru::View::Plot, 'plotting with googlecharts' do
   before { Daru::View.plotting_library = :googlecharts }
   before(:each) do
-    @data_array = [[1, 15], [2, 30], [4, 40]]
+    @data_array1 = [[1, 15], [2, 30], [4, 40]]
     @data_vec1 = Daru::Vector.new([1 ,2, 4])
     @data_vec2 = Daru::Vector.new([15 ,30, 40])
     @data_df = Daru::DataFrame.new(arr1: @data_vec1, arr2: @data_vec2)
-
     @options = {width: 800, height: 720}
 
     @plot = Daru::View::Plot.new(@data_df, @options)
+
+    @data_hash = {
+      cols: [
+              {id: 'Name', label: 'Name', type: 'string'},
+              {id: 'Salary', label: 'Salary', type: 'number'},
+              {type: 'boolean', label: 'Full Time Employee' },
+            ],
+      rows: [
+              {c:[{v: 'Mike'}, {v: 10000, f: '$10,000'}, {v: true}]},
+              {c:[{v: 'Jim'}, {v:8000,   f: '$8,000'}, {v: false}]},
+              {c:[{v: 'Alice'}, {v: 12500, f: '$12,500'}, {v: true}]},
+              {c:[{v: 'Bob'}, {v: 7000,  f: '$7,000'}, {v: true}]},
+            ]
+    }
+
+    @data_array2 = [
+      ['Galaxy', 'Distance', 'Brightness'],
+      ['Canis Major Dwarf', 8000, 230.3],
+      ['Sagittarius Dwarf', 24000, 4000.5],
+      ['Ursa Major II Dwarf', 30000, 1412.3],
+      ['Lg. Magellanic Cloud', 50000, 120.9],
+      ['Bootes I', 60000, 1223.1]
+    ]
   end
 
   describe "initialization Charts" do
@@ -35,6 +57,27 @@ describe Daru::View::Plot, 'plotting with googlecharts' do
       expect(Daru::View::Table.new(@data_vec1, @options).table).to be_a GoogleVisualr::DataTable
       expect(Daru::View::Table.new(@data_vec1, @options).options).to eq @options
       expect(Daru::View::Table.new(@data_vec1, @options).data).to eq @data_vec1
+    end
+    it "Table class must be GoogleVisualr::DataTable when data objects are" \
+       " of class Daru::DataFrame" do
+      expect(Daru::View::Table.new(@data_df, @options).table).to be_a GoogleVisualr::DataTable
+      expect(Daru::View::Table.new(@data_df, @options).options).to eq @options
+      expect(Daru::View::Table.new(@data_df, @options).data).to eq @data_df
+    end
+    it "Table class must be GoogleVisualr::DataTable when data objects are" \
+       " of class Array" do
+      expect(Daru::View::Table.new(@data_array2, @options).table).to be_a GoogleVisualr::DataTable
+      expect(Daru::View::Table.new(@data_array2, @options).options).to eq @options
+      expect(Daru::View::Table.new(@data_array2, @options).data).to eq @data_array2
+    end
+    it "Table class must be GoogleVisualr::DataTable when data objects are" \
+       " of class Hash" do
+      expect(Daru::View::Table.new(@data_hash, @options).table).to be_a GoogleVisualr::DataTable
+      expect(Daru::View::Table.new(@data_hash, @options).options).to eq @options
+      expect(Daru::View::Table.new(@data_hash, @options).data).to eq @data_hash
+    end
+    it "Raise error when data objects are none of the above" do
+      expect{Daru::View::Table.new("daru")}.to raise_error(ArgumentError) 
     end
   end
 end

--- a/spec/adapters/googlecharts_spec.rb
+++ b/spec/adapters/googlecharts_spec.rb
@@ -8,9 +8,7 @@ describe Daru::View::Plot, 'plotting with googlecharts' do
     @data_vec2 = Daru::Vector.new([15 ,30, 40])
     @data_df = Daru::DataFrame.new(arr1: @data_vec1, arr2: @data_vec2)
     @options = {width: 800, height: 720}
-
     @plot = Daru::View::Plot.new(@data_df, @options)
-
     @data_hash = {
       cols: [
               {id: 'Name', label: 'Name', type: 'string'},
@@ -24,7 +22,6 @@ describe Daru::View::Plot, 'plotting with googlecharts' do
               {c:[{v: 'Bob'}, {v: 7000,  f: '$7,000'}, {v: true}]},
             ]
     }
-
     @data_array2 = [
       ['Galaxy', 'Distance', 'Brightness'],
       ['Canis Major Dwarf', 8000, 230.3],
@@ -33,12 +30,16 @@ describe Daru::View::Plot, 'plotting with googlecharts' do
       ['Lg. Magellanic Cloud', 50000, 120.9],
       ['Bootes I', 60000, 1223.1]
     ]
+    @table_array = Daru::View::Table.new(@data_array2, @options)
+    @table_dv = Daru::View::Table.new(@data_vec1, @options)
+    @table_df = Daru::View::Table.new(@data_df, @options)
+    @table_hash = Daru::View::Table.new(@data_hash, @options)
   end
 
   describe "initialization Charts" do
     it "Default chart GoogleVisualr::Interactive::LineChart " do
-      expect(Daru::View::Plot.new.chart
-        ).to be_a GoogleVisualr::Interactive::LineChart
+      expect(Daru::View::Plot.new.chart)
+      .to be_a GoogleVisualr::Interactive::LineChart
     end
     it "Bar chart GoogleVisualr::Interactive::BarChart " do
       expect(Daru::View::Plot.new(
@@ -61,57 +62,27 @@ describe Daru::View::Plot, 'plotting with googlecharts' do
     end
     it "Table class must be GoogleVisualr::DataTable when data objects are" \
        " of class Daru::Vector" do
-      expect(Daru::View::Table.new(
-        @data_vec1,
-        @options).table
-      ).to be_a GoogleVisualr::DataTable
-      expect(Daru::View::Table.new(
-        @data_vec1,
-        @options).options
-      ).to eq @options
-      expect(Daru::View::Table.new(
-        @data_vec1,
-        @options).data
-      ).to eq @data_vec1
+      expect(@table_dv.table).to be_a GoogleVisualr::DataTable
+      expect(@table_dv.options).to eq @options
+      expect(@table_dv.data).to eq @data_vec1
     end
     it "Table class must be GoogleVisualr::DataTable when data objects are" \
        " of class Daru::DataFrame" do
-      expect(Daru::View::Table.new(
-        @data_df,
-        @options).table
-      ).to be_a GoogleVisualr::DataTable
-      expect(Daru::View::Table.new(@data_df, @options).options).to eq @options
-      expect(Daru::View::Table.new(@data_df, @options).data).to eq @data_df
+      expect(@table_df.table).to be_a GoogleVisualr::DataTable
+      expect(@table_df.options).to eq @options
+      expect(@table_df.data).to eq @data_df
     end
     it "Table class must be GoogleVisualr::DataTable when data objects are" \
        " of class Array" do
-      expect(Daru::View::Table.new(
-        @data_array2,
-        @options).table
-      ).to be_a GoogleVisualr::DataTable
-      expect(Daru::View::Table.new(
-        @data_array2,
-        @options).options
-      ).to eq @options
-      expect(Daru::View::Table.new(
-        @data_array2,
-        @options).data
-      ).to eq @data_array2
+      expect(@table_array.table).to be_a GoogleVisualr::DataTable
+      expect(@table_array.options).to eq @options
+      expect(@table_array.data).to eq @data_array2
     end
     it "Table class must be GoogleVisualr::DataTable when data objects are" \
        " of class Hash" do
-      expect(Daru::View::Table.new(
-        @data_hash,
-        @options).table
-      ).to be_a GoogleVisualr::DataTable
-      expect(Daru::View::Table.new(
-        @data_hash,
-        @options).options
-      ).to eq @options
-      expect(Daru::View::Table.new(
-        @data_hash,
-        @options).data
-      ).to eq @data_hash
+      expect(@table_hash.table).to be_a GoogleVisualr::DataTable
+      expect(@table_hash.options).to eq @options
+      expect(@table_hash.data).to eq @data_hash
     end
     it "Raise error when data objects are none of the above" do
       expect{Daru::View::Table.new("daru")}.to raise_error(ArgumentError) 

--- a/spec/adapters/googlecharts_spec.rb
+++ b/spec/adapters/googlecharts_spec.rb
@@ -37,13 +37,20 @@ describe Daru::View::Plot, 'plotting with googlecharts' do
 
   describe "initialization Charts" do
     it "Default chart GoogleVisualr::Interactive::LineChart " do
-      expect(Daru::View::Plot.new.chart).to be_a GoogleVisualr::Interactive::LineChart
+      expect(Daru::View::Plot.new.chart
+        ).to be_a GoogleVisualr::Interactive::LineChart
     end
     it "Bar chart GoogleVisualr::Interactive::BarChart " do
-      expect(Daru::View::Plot.new([], type: :bar).chart).to be_a GoogleVisualr::Interactive::BarChart
+      expect(Daru::View::Plot.new(
+        [],
+        type: :bar).chart
+      ).to be_a GoogleVisualr::Interactive::BarChart
     end
     it "Column chart GoogleVisualr::Interactive::ColumnChart " do
-      expect(Daru::View::Plot.new([], type: :column).chart).to be_a GoogleVisualr::Interactive::ColumnChart
+      expect(Daru::View::Plot.new(
+        [],
+        type: :column).chart
+      ).to be_a GoogleVisualr::Interactive::ColumnChart
     end
     # TODO: all other kinds of charts
   end
@@ -54,27 +61,57 @@ describe Daru::View::Plot, 'plotting with googlecharts' do
     end
     it "Table class must be GoogleVisualr::DataTable when data objects are" \
        " of class Daru::Vector" do
-      expect(Daru::View::Table.new(@data_vec1, @options).table).to be_a GoogleVisualr::DataTable
-      expect(Daru::View::Table.new(@data_vec1, @options).options).to eq @options
-      expect(Daru::View::Table.new(@data_vec1, @options).data).to eq @data_vec1
+      expect(Daru::View::Table.new(
+        @data_vec1,
+        @options).table
+      ).to be_a GoogleVisualr::DataTable
+      expect(Daru::View::Table.new(
+        @data_vec1,
+        @options).options
+      ).to eq @options
+      expect(Daru::View::Table.new(
+        @data_vec1,
+        @options).data
+      ).to eq @data_vec1
     end
     it "Table class must be GoogleVisualr::DataTable when data objects are" \
        " of class Daru::DataFrame" do
-      expect(Daru::View::Table.new(@data_df, @options).table).to be_a GoogleVisualr::DataTable
+      expect(Daru::View::Table.new(
+        @data_df,
+        @options).table
+      ).to be_a GoogleVisualr::DataTable
       expect(Daru::View::Table.new(@data_df, @options).options).to eq @options
       expect(Daru::View::Table.new(@data_df, @options).data).to eq @data_df
     end
     it "Table class must be GoogleVisualr::DataTable when data objects are" \
        " of class Array" do
-      expect(Daru::View::Table.new(@data_array2, @options).table).to be_a GoogleVisualr::DataTable
-      expect(Daru::View::Table.new(@data_array2, @options).options).to eq @options
-      expect(Daru::View::Table.new(@data_array2, @options).data).to eq @data_array2
+      expect(Daru::View::Table.new(
+        @data_array2,
+        @options).table
+      ).to be_a GoogleVisualr::DataTable
+      expect(Daru::View::Table.new(
+        @data_array2,
+        @options).options
+      ).to eq @options
+      expect(Daru::View::Table.new(
+        @data_array2,
+        @options).data
+      ).to eq @data_array2
     end
     it "Table class must be GoogleVisualr::DataTable when data objects are" \
        " of class Hash" do
-      expect(Daru::View::Table.new(@data_hash, @options).table).to be_a GoogleVisualr::DataTable
-      expect(Daru::View::Table.new(@data_hash, @options).options).to eq @options
-      expect(Daru::View::Table.new(@data_hash, @options).data).to eq @data_hash
+      expect(Daru::View::Table.new(
+        @data_hash,
+        @options).table
+      ).to be_a GoogleVisualr::DataTable
+      expect(Daru::View::Table.new(
+        @data_hash,
+        @options).options
+      ).to eq @options
+      expect(Daru::View::Table.new(
+        @data_hash,
+        @options).data
+      ).to eq @data_hash
     end
     it "Raise error when data objects are none of the above" do
       expect{Daru::View::Table.new("daru")}.to raise_error(ArgumentError) 


### PR DESCRIPTION
Partial fix for the issue #67.
Tests were already present for an empty array being passed to the `data` parameter.
Adding tests when a vector is passed as `data`.
It also improves coverage for the method add_vector_data: https://github.com/SciRuby/daru-view/blob/master/lib/daru/view/adapters/googlecharts.rb#L154-L160.

I also wanted to add tests for the method return_js_type: https://github.com/SciRuby/daru-view/blob/master/lib/daru/view/adapters/googlecharts.rb#L173-#L188. 
I have tried testing it as: 
    `it "when data is of class type String" do
      expect(Daru::View::Adapter::GooglechartsAdapter.return_js_type("daru")).to eq "string"
     end`
But as this method is a private method and it is recommended not to test the private methods, is it possible if we could test it using ruby's send method?
