### PR TITLE
Rake task to add new adapter template

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ For now, other applications (Rails/Sinatra) you need to run it locally.
   daru-view
   ```
 
-  - To update al the JS files:
+  - To update all the JS files:
   ```
   daru-view update
   ```
@@ -297,7 +297,7 @@ For now, other applications (Rails/Sinatra) you need to run it locally.
 
 ### 2. Developers
 
-  To update to the current highcharts.js directly from http://code.highcharts.com/",  you can always run
+  To update to the current highcharts.js directly from http://code.highcharts.com/", you can always run
 
     rake highcharts:update
 
@@ -309,6 +309,14 @@ For now, other applications (Rails/Sinatra) you need to run it locally.
 
     rake update_all
 
+## Creating a new adapter (Developers)
+
+  To create a new adapter `Demo`, run
+  ```
+  rake new:adapter Demo
+  ```
+
+  and a file demo.rb will be created in the daru/view/adapters folder with all the necessary methods (init, init_script, init_ruby, generate_body, show_in_iruby and export_html_file) as TODO.
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ Coveralls::RakeTask.new
 import 'lib/tasks/high_charts.rake'
 import 'lib/tasks/nyaplot.rake'
 import 'lib/tasks/google_charts.rake'
+import 'lib/tasks/new_adapter.rake'
 
 # TODO: add Nyaplot
 task :update_all => ["googlecharts:update", "highcharts:update"]
-

--- a/lib/tasks/new_adapter.rake
+++ b/lib/tasks/new_adapter.rake
@@ -1,0 +1,47 @@
+def extract_adapter_template_code(file_name, template_code_str)
+  template_code_str << "module Daru"
+  template_code_str << "\n  module View"
+  template_code_str << "\n    module Adapter"
+  template_code_str << "\n      module #{file_name.capitalize}Adapter"
+  template_code_str << "\n        extend self # rubocop:disable Style/ModuleFunction"
+  template_code_str << "\n        def init(data, options, _user_options={})"
+  template_code_str << "\n          # TODO"
+  template_code_str << "\n        end"
+  template_code_str << "\n"
+  template_code_str << "\n        def export_html_file(plot, path='./plot.html')"
+  template_code_str << "\n          # TODO"
+  template_code_str << "\n        end"
+  template_code_str << "\n"
+  template_code_str << "\n        def show_in_iruby(plot)"
+  template_code_str << "\n          # TODO"
+  template_code_str << "\n        end"
+  template_code_str << "\n"
+  template_code_str << "\n        def init_script"
+  template_code_str << "\n          # TODO"
+  template_code_str << "\n        end"
+  template_code_str << "\n"
+  template_code_str << "\n        def init_iruby"
+  template_code_str << "\n          # TODO"
+  template_code_str << "\n        end"
+  template_code_str << "\n      end"
+  template_code_str << "\n    end"
+  template_code_str << "\n  end"
+  template_code_str << "\nend"
+  template_code_str << "\n"
+end
+
+namespace :new do  
+  desc "Generate a sample template for the new adapter"
+  task :adapter do
+    print "Creating new adapter..."
+    ARGV.each { |a| task a.to_sym do ; end }
+    file_name = ARGV[1].to_s
+    path = File.expand_path(
+            '../daru/view/adapters/' + file_name + '.rb', __dir__
+          )
+    template_code_str = ''
+    extract_adapter_template_code(file_name, template_code_str)
+    File.write(path, template_code_str)
+    puts "Done."
+  end
+end

--- a/lib/tasks/new_adapter.rake
+++ b/lib/tasks/new_adapter.rake
@@ -4,40 +4,39 @@ def extract_adapter_template_code(file_name, template_code_str)
   template_code_str << "\n    module Adapter"
   template_code_str << "\n      module #{file_name.capitalize}Adapter"
   template_code_str << "\n        extend self # rubocop:disable Style/ModuleFunction"
-  template_code_str << "\n        def init(data, options, _user_options={})"
-  template_code_str << "\n          # TODO"
-  template_code_str << "\n          raise NotImplementedError, 'Not yet implemented'"
-  template_code_str << "\n        end"
+  template_code_str << append_method('init', ['data', 'options', '_user_options'])
   template_code_str << "\n"
-  template_code_str << "\n        def export_html_file(plot, path='./plot.html')"
-  template_code_str << "\n          # TODO"
-  template_code_str << "\n          raise NotImplementedError, 'Not yet implemented'"
-  template_code_str << "\n        end"
+  template_code_str << append_method('export_html_file', ['plot', "path='./plot.html'"])
   template_code_str << "\n"
-  template_code_str << "\n        def show_in_iruby(plot)"
-  template_code_str << "\n          # TODO"
-  template_code_str << "\n          raise NotImplementedError, 'Not yet implemented'"
-  template_code_str << "\n        end"
+  template_code_str << append_method('show_in_iruby', ['plot'])
   template_code_str << "\n"
-  template_code_str << "\n        def init_script"
-  template_code_str << "\n          # TODO"
-  template_code_str << "\n          raise NotImplementedError, 'Not yet implemented'"
-  template_code_str << "\n        end"
+  template_code_str << append_method('init_script')
   template_code_str << "\n"
-  template_code_str << "\n        def generate_body(plot)"
-  template_code_str << "\n          # TODO"
-  template_code_str << "\n          raise NotImplementedError, 'Not yet implemented'"
-  template_code_str << "\n        end"
+  template_code_str << append_method('generate_body', ['plot'])
   template_code_str << "\n"
-  template_code_str << "\n        def init_iruby"
-  template_code_str << "\n          # TODO"
-  template_code_str << "\n          raise NotImplementedError, 'Not yet implemented'"
-  template_code_str << "\n        end"
+  template_code_str << append_method('init_iruby')
   template_code_str << "\n      end"
   template_code_str << "\n    end"
   template_code_str << "\n  end"
   template_code_str << "\nend"
   template_code_str << "\n"
+end
+
+def append_method(method_name, params=nil)
+  method_str = "\n        def #{method_name}"
+  if params
+    method_str << '('
+    method_str << params.join(', ')
+    method_str << ')'
+  end
+  method_str << append_method_body(method_name, params)
+  method_str << "\n        end"
+end
+
+def append_method_body(_method_name, _params)
+  method_body = "\n          # TODO"
+  method_body << "\n          raise NotImplementedError, 'Not yet implemented'"
+  method_body
 end
 
 namespace :new do  

--- a/lib/tasks/new_adapter.rake
+++ b/lib/tasks/new_adapter.rake
@@ -6,22 +6,32 @@ def extract_adapter_template_code(file_name, template_code_str)
   template_code_str << "\n        extend self # rubocop:disable Style/ModuleFunction"
   template_code_str << "\n        def init(data, options, _user_options={})"
   template_code_str << "\n          # TODO"
+  template_code_str << "\n          raise NotImplementedError, 'Not yet implemented'"
   template_code_str << "\n        end"
   template_code_str << "\n"
   template_code_str << "\n        def export_html_file(plot, path='./plot.html')"
   template_code_str << "\n          # TODO"
+  template_code_str << "\n          raise NotImplementedError, 'Not yet implemented'"
   template_code_str << "\n        end"
   template_code_str << "\n"
   template_code_str << "\n        def show_in_iruby(plot)"
   template_code_str << "\n          # TODO"
+  template_code_str << "\n          raise NotImplementedError, 'Not yet implemented'"
   template_code_str << "\n        end"
   template_code_str << "\n"
   template_code_str << "\n        def init_script"
   template_code_str << "\n          # TODO"
+  template_code_str << "\n          raise NotImplementedError, 'Not yet implemented'"
+  template_code_str << "\n        end"
+  template_code_str << "\n"
+  template_code_str << "\n        def generate_body(plot)"
+  template_code_str << "\n          # TODO"
+  template_code_str << "\n          raise NotImplementedError, 'Not yet implemented'"
   template_code_str << "\n        end"
   template_code_str << "\n"
   template_code_str << "\n        def init_iruby"
   template_code_str << "\n          # TODO"
+  template_code_str << "\n          raise NotImplementedError, 'Not yet implemented'"
   template_code_str << "\n        end"
   template_code_str << "\n      end"
   template_code_str << "\n    end"
@@ -35,7 +45,7 @@ namespace :new do
   task :adapter do
     print "Creating new adapter..."
     ARGV.each { |a| task a.to_sym do ; end }
-    file_name = ARGV[1].to_s
+    file_name = ARGV[1].to_s.downcase
     path = File.expand_path(
             '../daru/view/adapters/' + file_name + '.rb', __dir__
           )

--- a/spec/new_adapter_spec.rb
+++ b/spec/new_adapter_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'new:adapter' do
+  it "runs the task new:adapter" do
+    Rake.application.rake_require 'tasks/new_adapter'
+    expect { Rake::Task['new:adapter'].invoke }.not_to raise_exception
+  end
+end


### PR DESCRIPTION
This PR aims to create a rake task to add a new adapter template.
Example:
> rake new:adapter Charts

will create a new file `charts.rb` with all the necessary methods to add an adapter like init, init_script, init_ruby, show_in_iruby and export_html_file as TODO.