### PR TITLE
Rename Daru::DataTables::DataTable to Daru::View::DataTable

### DIFF
--- a/lib/daru/view.rb
+++ b/lib/daru/view.rb
@@ -99,7 +99,7 @@ module Daru
         when 'googlecharts'
           GoogleVisualr.init_script
         when 'datatables'
-          DataTables.init_script
+          init_script
         else
           raise ArgumentError, "Unsupported library #{lib}"
         end
@@ -146,8 +146,7 @@ module Daru
           library = 'GoogleVisualr'
           Object.const_get(library).init_iruby
         elsif library.match('datatables')
-          library = 'DataTables'
-          Object.const_get(library).init_iruby
+          init_iruby
         else
           Object.const_get(library.capitalize).init_iruby
         end

--- a/lib/daru/view.rb
+++ b/lib/daru/view.rb
@@ -99,7 +99,7 @@ module Daru
         when 'googlecharts'
           GoogleVisualr.init_script
         when 'datatables'
-          init_script
+          DataTables.init_script
         else
           raise ArgumentError, "Unsupported library #{lib}"
         end
@@ -146,7 +146,8 @@ module Daru
           library = 'GoogleVisualr'
           Object.const_get(library).init_iruby
         elsif library.match('datatables')
-          init_iruby
+          library = 'DataTables'
+          Object.const_get(library).init_iruby
         else
           Object.const_get(library.capitalize).init_iruby
         end

--- a/lib/daru/view/adapters/datatables.rb
+++ b/lib/daru/view/adapters/datatables.rb
@@ -64,7 +64,7 @@ module Daru
 
         # @return [String] returns code of the dependent JS and CSS file(s)
         def init_script
-          Daru::View.init_script
+          Daru::View::DataTables.init_script
         end
 
         # @param table [Daru::DataTables::DataTable] table object to access
@@ -116,7 +116,7 @@ module Daru
         #   table = Daru::View::Table.new(data, options)
         #   table.init_iruby
         def init_iruby
-          Daru::View.init_iruby
+          Daru::View::DataTables.init_iruby
         end
       end
     end

--- a/lib/daru/view/adapters/datatables.rb
+++ b/lib/daru/view/adapters/datatables.rb
@@ -1,4 +1,3 @@
-require 'daru/data_tables'
 require 'daru'
 require 'securerandom'
 require 'erb'
@@ -59,13 +58,13 @@ module Daru
         #     table2 = Daru::View::Table.new(df_sale_exp, options2)
         #     table3 = Daru::View::Table.new(df_sale_exp)
         def init_table(data=[], options={}, _user_options={})
-          @table = Daru::DataTables::DataTable.new(data, options)
+          @table = Daru::View::DataTable.new(data, options)
           @table
         end
 
         # @return [String] returns code of the dependent JS and CSS file(s)
         def init_script
-          Daru::DataTables.init_script
+          Daru::View.init_script
         end
 
         # @param table [Daru::DataTables::DataTable] table object to access
@@ -117,7 +116,7 @@ module Daru
         #   table = Daru::View::Table.new(data, options)
         #   table.init_iruby
         def init_iruby
-          Daru::DataTables.init_iruby
+          Daru::View.init_iruby
         end
       end
     end

--- a/spec/adapters/datatables_spec.rb
+++ b/spec/adapters/datatables_spec.rb
@@ -18,20 +18,20 @@ describe Daru::View::Table, 'table using daru-data_tables' do
   let(:table_dv) { Daru::View::Table.new(@data_vec1, @options) }
 
   describe "initialization Tables" do
-    it "Table class must be Daru::DataTables::DataTable" do
-      expect(Daru::View::Table.new.table).to be_a Daru::DataTables::DataTable
+    it "Table class must be Daru::View::DataTable" do
+      expect(Daru::View::Table.new.table).to be_a Daru::View::DataTable
     end
 
-    it "Table class must be Daru::DataTables::DataTable when data objects" \
+    it "Table class must be Daru::View::DataTable when data objects" \
        " are of class Array" do
-      expect(table_string_array.table).to be_a Daru::DataTables::DataTable
+      expect(table_string_array.table).to be_a Daru::View::DataTable
       expect(table_string_array.data).to eq string_array
       expect(table_string_array.options).to eq options
     end
 
-    it "Table class must be Daru::DataTables::DataTable when data objects" \
+    it "Table class must be Daru::View::DataTable when data objects" \
        " are of class Array of Arrays" do
-      expect(table_array.table).to be_a Daru::DataTables::DataTable
+      expect(table_array.table).to be_a Daru::View::DataTable
       expect(table_array.data).to eq data_array
       expect(table_array.options).to eq options
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rspec'
 require 'simplecov'
 require 'daru/view'
+require 'daru/data_tables'
 require 'daru'
 require 'coveralls'
 require 'simplecov-console'

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -70,14 +70,14 @@ describe Daru::View::Table, 'Generating Table with daru-data_tables library' do
 
     it 'daru-data_tables table using DataFrame' do
       expect(table_df).to be_a Daru::View::Table
-      expect(table_df.table).to be_a Daru::DataTables::DataTable
+      expect(table_df.table).to be_a Daru::View::DataTable
       expect(table_df.options).to eq options
       expect(table_df.data).to eq df
     end
 
     it 'daru-data_tables table using Vector' do
       expect(table_dv).to be_a Daru::View::Table
-      expect(table_dv.table).to be_a Daru::DataTables::DataTable
+      expect(table_dv.table).to be_a Daru::View::DataTable
       expect(table_dv.options).to eq options
       expect(table_dv.data).to eq dv
     end


### PR DESCRIPTION
Updated specs and renamed `Daru::DataTables::DataTable` to `Daru::View::DataTable`.
This PR runs in parallel with [#22](https://github.com/Shekharrajak/daru-data_tables/pull/22/) in daru-data_tables, so some of the test cases will not work right now.