### PR TITLE
Fixed Rubocop offenses coming from version0.60

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,7 @@ AllCops:
     - 'bin/*'
     - 'daru-view.gemspec'
     - '**/*.rake'
+    - '**/.rb'
   DisplayCopNames: true
   TargetRubyVersion: 2.2
 

--- a/lib/daru/view/adapters/googlecharts.rb
+++ b/lib/daru/view/adapters/googlecharts.rb
@@ -170,6 +170,7 @@ module Daru
           #  versions
           # For testing purpose, it is returning true
           return true if data.match(PATTERN_URL)
+
           raise 'Invalid URL'
         end
 

--- a/lib/daru/view/adapters/googlecharts.rb
+++ b/lib/daru/view/adapters/googlecharts.rb
@@ -201,6 +201,7 @@ module Daru
         def export(plot, export_type='png', file_name='chart')
           raise NotImplementedError, 'Not yet implemented!' unless
           export_type == 'png'
+
           plot.export_iruby(export_type, file_name) if defined? IRuby
         rescue NameError
           plot.export(export_type, file_name)
@@ -268,11 +269,13 @@ module Daru
           case
           when data_set.is_a?(Daru::DataFrame)
             return ArgumentError unless data_set.index.is_a?(Daru::Index)
+
             rows = add_dataframe_data(data_set)
           when data_set.is_a?(Daru::Vector)
             rows = add_vector_data(data_set)
           when data_set.is_a?(Array)
             return GoogleVisualr::DataTable.new if data_set.empty?
+
             rows = add_array_data(data_set)
           when data_set.is_a?(Hash)
             @table = GoogleVisualr::DataTable.new(data_set)
@@ -329,6 +332,7 @@ module Daru
 
         def return_js_type(data)
           return if data.nil?
+
           data = data.is_a?(Hash) ? data[:v] : data
           extract_js_type(data)
         end

--- a/lib/daru/view/adapters/googlecharts/base_chart.rb
+++ b/lib/daru/view/adapters/googlecharts/base_chart.rb
@@ -15,6 +15,7 @@ module GoogleVisualr
     # @see #GooleVisualr::DataTable.extract_option_view
     def extract_option_view
       return js_parameters(@options.delete('view')) unless @options['view'].nil?
+
       '\'\''
     end
 

--- a/lib/daru/view/adapters/googlecharts/data_table_iruby.rb
+++ b/lib/daru/view/adapters/googlecharts/data_table_iruby.rb
@@ -33,6 +33,7 @@ module GoogleVisualr
       new_columns(options[:cols]) unless options[:cols].nil?
 
       return if options[:rows].nil?
+
       rows = options[:rows]
       rows.each do |row|
         add_row(row[:c])
@@ -74,6 +75,7 @@ module GoogleVisualr
     def package_name
       return 'table' unless
       user_options && user_options[:chart_class].to_s.capitalize == 'Charteditor'
+
       'charteditor'
     end
 
@@ -81,6 +83,7 @@ module GoogleVisualr
     #   and '' otherwise
     def extract_option_view
       return js_parameters(@options.delete(:view)) unless @options[:view].nil?
+
       '\'\''
     end
 

--- a/lib/daru/view/adapters/googlecharts/display.rb
+++ b/lib/daru/view/adapters/googlecharts/display.rb
@@ -167,6 +167,7 @@ module Display
   #   user_options[:listeners]
   def add_listener_to_chart
     return unless user_options && user_options[:listeners]
+
     user_options[:listeners].each do |event, callback|
       add_listener(event.to_s.downcase, callback)
     end
@@ -178,6 +179,7 @@ module Display
   #   third parameter
   def apply_formatters
     return unless user_options && user_options[:formatters]
+
     @formatters = []
     user_options[:formatters].each_value do |formatter|
       frmttr = case formatter[:type].to_s.capitalize

--- a/lib/daru/view/adapters/googlecharts/generate_javascript.rb
+++ b/lib/daru/view/adapters/googlecharts/generate_javascript.rb
@@ -24,6 +24,7 @@ module GenerateJavascript
   #   draw the Chartwrapper based upon the data provided.
   def append_data(data)
     return "\n  \t\tdataSourceUrl: '#{data}'," if data.is_a? String
+
     "\n  \t\tdataTable: data_table,"
   end
 

--- a/lib/daru/view/adapters/highcharts.rb
+++ b/lib/daru/view/adapters/highcharts.rb
@@ -116,6 +116,7 @@ module Daru
           when data_set.is_a?(Daru::DataFrame)
             # TODO : Currently I didn't find use case for multi index.
             return ArgumentError unless data_set.index.is_a?(Daru::Index)
+
             index_val = data_set.index.to_a
             data_set.access_row_tuples_by_indexs(*index_val)
           when data_set.is_a?(Daru::Vector)

--- a/lib/daru/view/adapters/highcharts/display.rb
+++ b/lib/daru/view/adapters/highcharts/display.rb
@@ -271,6 +271,7 @@ module LazyHighCharts
       unless %w[Chart StockChart Map].include?(chart_class)
         raise 'chart_class must be selected as either chart, stock or map'
       end
+
       chart_class
     end
 

--- a/lib/daru/view/plot_list.rb
+++ b/lib/daru/view/plot_list.rb
@@ -77,6 +77,7 @@ module Daru
         return plot.div unless defined?(IRuby.html) &&
                                plot.is_a?(Daru::View::Plot) &&
                                plot.chart.is_a?(LazyHighCharts::HighChart)
+
         plot.chart.to_html_iruby
       end
 


### PR DESCRIPTION
Most of the offensed were  : 

Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
