### PR TITLE
switch to Kenneth-KT version of google visual r

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gemspec
 # TODO: later we will use the recent version of daru gem.
 gem "daru", '0.2.0'
 gem "nyaplot", git: 'https://github.com/SciRuby/nyaplot.git'
-gem 'google_visualr', git: 'https://github.com/winston/google_visualr.git'
+gem 'google_visualr_rails5'
 
 gem 'daru-data_tables', git: 'https://github.com/Shekharrajak/daru-data_tables.git'
 

--- a/daru-view.gemspec
+++ b/daru-view.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
 
   # fetching latest gem from the Gemfile
-  spec.add_runtime_dependency 'google_visualr'
+  spec.add_runtime_dependency 'google_visualr_rails5'
   spec.add_runtime_dependency 'lazy_high_charts'
   spec.add_runtime_dependency 'daru'
   spec.add_runtime_dependency 'nyaplot'


### PR DESCRIPTION
switch to Kenneth-KT version of google visual r because the old version is broken

#### References to other Issues or PRs
Fixes #168


#### Brief description of what is fixed or changed

switch to Kenneth-KT version of google visual r because the old version is broken

#### Testcase / documentation

switch to Kenneth-KT version of google visual r because the old version is broken

#### Other comments
Not sure how to test this. I believe this should address the issue though
